### PR TITLE
fix go.mod module name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/dejavuzhou/felix
+module github.com/libragen/felix
 
 go 1.12
 


### PR DESCRIPTION
fix go.mod module name

fix go get  github.com/libragen/felix error 