### PR TITLE
Fix tpl_core.go create directory permissions

### DIFF
--- a/ginbro/tpl_core.go
+++ b/ginbro/tpl_core.go
@@ -23,7 +23,7 @@ func (n *tplNode) ParseExecute(appDir, pathArg string, data interface{}) error {
 		p = n.NameFormat
 	}
 	p = filepath.Clean(filepath.Join(appDir, p))
-	err := os.MkdirAll(filepath.Dir(p), 644)
+	err := os.MkdirAll(filepath.Dir(p), 0644)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Changed created directory permissions from 644 (-w----r--) to 0644 (rw-r--r--) when calling `MkdirAll(...)`.

PoC:
```
dc@jhtc:~/gogo/makedir$ cat main.go
package main

import "os"

func main() {
    os.MkdirAll("644", 644)
    os.MkdirAll("0644", 0644)
}
dc@jhtc:~/gogo/makedir$ go run main.go
ls dc@jhtc:~/gogo/makedir$ ls -la
total 20
drwxrwxr-x 4 dc dc 4096 Jun  9 17:10 .
drwxrwxr-x 5 dc dc 4096 Jun  9 17:10 ..
drw-r--r-- 2 dc dc 4096 Jun  9 17:10 0644
d-w----r-- 2 dc dc 4096 Jun  9 17:10 644
-rw-rw-r-- 1 dc dc  101 Jun  9 17:05 main.go
```